### PR TITLE
fix: changed placeholder in example-form

### DIFF
--- a/src/app/examples/form/form.component.html
+++ b/src/app/examples/form/form.component.html
@@ -27,7 +27,7 @@
               <m-input placeholder="First Name"></m-input>
             </m-field>
             <m-field name="shipping[last-name]">
-              <m-input placeholder="First Name"></m-input>
+              <m-input placeholder="Last Name"></m-input>
             </m-field>
           </m-field-group>
         </m-field>


### PR DESCRIPTION
Changed the incorrect placeholder at shipping form from "First Name" to "Last Name" 